### PR TITLE
Use BaseController for API

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,4 +1,0 @@
-module Api
-  class ApplicationController < ApplicationController
-  end
-end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class BaseController < ActionController::API
+  end
+end

--- a/app/controllers/api/home_controller.rb
+++ b/app/controllers/api/home_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class HomeController < Api::ApplicationController
+  class HomeController < BaseController
     def index
       render json: { ok: true }
     end

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class PostsController < Api::ApplicationController
+  class PostsController < BaseController
     def index
       # An example API endpoint to return a list of posts.
       # Here we just call an external placeholder API to get some posts.

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe Api::BaseController do
+  it { should be_a ActionController::API }
+end

--- a/spec/controllers/api/home_controller_spec.rb
+++ b/spec/controllers/api/home_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe Api::HomeController do
+  it { should be_a Api::BaseController }
+end

--- a/spec/controllers/api/posts_controller_spec.rb
+++ b/spec/controllers/api/posts_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe Api::PostsController do
+  it { should be_a Api::BaseController }
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe ApplicationController do
+  it { should be_a ActionController::Base }
+end

--- a/spec/request/api/posts_spec.rb
+++ b/spec/request/api/posts_spec.rb
@@ -7,6 +7,5 @@ RSpec.describe "api/posts", type: :request do
       expect(json_body.size).to eq(100)
       expect(json_body.first.keys).to eq(['userId', 'id', 'title', 'body'])
     end
-
   end
 end


### PR DESCRIPTION
This uses the lightweight version of the rails ontroller which is faster and reduces memory.

https://github.com/marcqualie/rails-vue-template/pull/new/rails-api

I also changed `Api::ApplicationController` to `Api::BaseController` since it's not actually the application controller, but rather the namespace base controller.

There's also controller tests to ensure the api controller extend the correct base, rather than the default application controller.